### PR TITLE
AcadEventManager: a probe that can actually confirm zero live hooks

### DIFF
--- a/Acad-C3D-Tools/EventManager/AcadEventManager.cs
+++ b/Acad-C3D-Tools/EventManager/AcadEventManager.cs
@@ -76,6 +76,32 @@ namespace EventManager
         public int GetSubscriptionCount(Document doc) => _subscriptions.CountFor(doc);
 
         /// <summary>
+        /// How many underlying AutoCAD hooks this manager is holding installed right now:
+        /// one per event somebody is subscribed to, plus the shared database hook and the
+        /// active-document database binding when those are up. Zero before the first
+        /// subscription, and zero again after <see cref="Dispose"/>.
+        /// </summary>
+        /// <remarks>
+        /// A teardown probe, not bookkeeping any consumer routes through -- its point is that
+        /// "the plugin unloaded and left nothing hooked" can be asserted rather than reasoned
+        /// about. <see cref="GetSubscriptions"/> answers a different question (how many
+        /// unsubscribe callbacks a plugin has parked against each document) and has never
+        /// known anything about these hooks, which is what made it the wrong instrument when
+        /// it was named for this job.
+        /// </remarks>
+        public int InstalledHookCount
+        {
+            get
+            {
+                int count = 0;
+                if (_dbHook.Installed) count++;
+                if (_dbBinding.Bound != null) count++;
+                foreach (IHookSlot slot in _slots) if (slot.Installed) count++;
+                return count;
+            }
+        }
+
+        /// <summary>
         /// Returns the slot backing one event, creating and registering it on first use.
         /// </summary>
         /// <exception cref="ObjectDisposedException">


### PR DESCRIPTION
Follow-up to #19, closing a **Missed** finding recorded in DimensioneringV2's deviations log for that wave.

`DamgaardRI/DimensioneringV2#66` shipped with an acceptance criterion it could not meet: *"`GetSubscriptions()` can be used to confirm zero live hooks after teardown."* `GetSubscriptions()` reports the per-document unsubscribe ledger and has never known anything about the 31 event hooks. The hook lifetime #66 changed is correct — there was simply no instrument pointed at it, so the criterion was unmeetable as worded.

`InstalledHookCount` is that instrument: the hook slots currently up, plus the shared database hook and the active-document database binding. Nothing routes through it; it exists so "the plugin unloaded and left nothing hooked" can be asserted instead of reasoned about.

Verified by building `DimensioneringV2.AutoCAD`, which compiles this shared project — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NGvut2Hny18csPnbyxcjF